### PR TITLE
Fix contrast across all UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diffuse Mode Solutioning</title>
+  <!--
+    To rename the GitHub repo from "household" to "diffuse-mode-solutioning":
+    GitHub → repo Settings → General → Repository name → rename
+    Then in Termux: git remote set-url origin https://github.com/pbannan/diffuse-mode-solutioning
+  -->
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body, #root { height: 100%; }
+    body { background: #0d0d0d; }
+    textarea { resize: none; }
+    textarea:focus { outline: none; }
+    input:focus { outline: none; }
+    ::-webkit-scrollbar { width: 4px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: #2a2a2a; border-radius: 2px; }
+
+    .tab { cursor: pointer; padding: 6px 0; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; border-bottom: 1px solid transparent; transition: all 0.2s; color: #777; user-select: none; }
+    .tab.active { color: #e8e4d9; border-bottom-color: #e8e4d9; }
+    .tab:hover { color: #999; }
+
+    .entry { border-bottom: 1px solid #1a1a1a; padding: 20px 0; animation: fi 0.3s ease; }
+    .entry:last-child { border-bottom: none; }
+    .entry.archived { opacity: 0.4; }
+
+    @keyframes fi { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+
+    .save-btn { background: #e8e4d9; color: #0d0d0d; border: none; padding: 10px 28px; font-family: 'IBM Plex Mono', monospace; font-size: 12px; letter-spacing: 0.1em; cursor: pointer; transition: opacity 0.2s; }
+    .save-btn:hover:not(:disabled) { opacity: 0.85; }
+    .save-btn:disabled { opacity: 0.4; cursor: default; }
+
+    .ghost-btn { background: transparent; color: #666; border: none; font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.1em; cursor: pointer; transition: color 0.2s; text-transform: uppercase; padding: 0; line-height: 1; }
+    .ghost-btn:hover { color: #888; }
+    .ghost-btn.danger:hover { color: #8a4a4a; }
+    .ghost-btn.accent:hover { color: #e8e4d9; }
+
+    .inline-btn { background: transparent; color: #555; border: none; font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.08em; cursor: pointer; transition: color 0.2s; padding: 0; line-height: 1; }
+    .inline-btn:hover { color: #999; }
+
+    .insight-btn { background: transparent; color: #555; border: 1px solid #2a2a2a; padding: 8px 20px; font-family: 'IBM Plex Mono', monospace; font-size: 11px; letter-spacing: 0.08em; cursor: pointer; transition: all 0.2s; }
+    .insight-btn:hover:not(:disabled) { color: #e8e4d9; border-color: #555; }
+    .insight-btn:disabled { opacity: 0.4; cursor: default; }
+
+    .chip { display: inline-flex; align-items: center; padding: 4px 10px; border: 1px solid #333; font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: 0.08em; cursor: pointer; transition: all 0.15s; color: #777; background: transparent; user-select: none; margin: 3px 3px 3px 0; }
+    .chip:hover { border-color: #555; color: #aaa; }
+    .chip.selected { border-color: #666; color: #c8c4b8; background: #161616; }
+
+    .field-label { font-size: 10px; letter-spacing: 0.14em; color: #666; text-transform: uppercase; margin-bottom: 10px; }
+
+    .text-area { width: 100%; background: #111; border: 1px solid #1e1e1e; color: #e8e4d9; font-family: 'IBM Plex Mono', monospace; font-size: 13px; padding: 14px 16px; line-height: 1.7; }
+    .text-area:focus { border-color: #2a2a2a; }
+
+    .tag-input { background: transparent; border: none; border-bottom: 1px solid #222; color: #777; font-family: 'IBM Plex Mono', monospace; font-size: 10px; padding: 3px 0; letter-spacing: 0.08em; width: 120px; }
+    .tag-input::placeholder { color: #444; }
+    .tag-input:focus { border-bottom-color: #444; }
+
+    .toggle-row { display: flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+    .toggle-box { width: 14px; height: 14px; border: 1px solid #333; display: flex; align-items: center; justify-content: center; transition: all 0.15s; flex-shrink: 0; }
+    .toggle-box.checked { border-color: #666; background: #1a1a1a; }
+    .toggle-box.checked::after { content: '×'; color: #c8c4b8; font-size: 11px; line-height: 1; }
+
+    .history-item { padding: 10px 0; border-bottom: 1px solid #161616; display: flex; gap: 12px; align-items: flex-start; }
+    .history-item:last-child { border-bottom: none; }
+
+    .key-input { width: 100%; background: #111; border: 1px solid #1e1e1e; color: #e8e4d9; font-family: 'IBM Plex Mono', monospace; font-size: 12px; padding: 10px 14px; letter-spacing: 0.04em; }
+    .key-input:focus { border-color: #333; }
+
+    .morning-block { margin-top: 14px; padding: 12px 14px; background: #0f0f0f; border-left: 1px solid #1e1e1e; animation: fi 0.3s ease; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, useRef } = React;
+
+    const STORAGE_KEY = "nightly-focus-log";
+    const API_KEY_STORAGE = "nightly-focus-api-key";
+    const NIGHT_PROMPT = "What is the one problem you want to work on tomorrow?";
+    const CATEGORIES = ["Last night's problem", "Work", "Personal", "Health", "Creative", "Relationships", "Other"];
+
+    function formatDate(iso) {
+      return new Date(iso).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+    }
+    function formatTime(iso) {
+      return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    }
+    function formatShortDate(iso) {
+      return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    }
+
+    function loadEntries() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+      } catch { return []; }
+    }
+    function persistEntries(entries) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    }
+
+    function blankMorning() {
+      return { wakingThoughts: "", categories: [], ideas: "", relatedToFocus: false };
+    }
+
+    function App() {
+      const [entries, setEntries] = useState(loadEntries);
+      const [view, setView] = useState("tonight");
+
+      // Tonight
+      const [nightInput, setNightInput] = useState("");
+      const [nightSaved, setNightSaved] = useState(false);
+
+      // Morning
+      const [morning, setMorning] = useState(blankMorning);
+      const [morningSaved, setMorningSaved] = useState(false);
+      const [morningEditing, setMorningEditing] = useState(false);
+      const [customTag, setCustomTag] = useState("");
+
+      // Log — edit
+      const [editingId, setEditingId] = useState(null);
+      const [editDraft, setEditDraft] = useState("");
+
+      // Log — history
+      const [expandedHistory, setExpandedHistory] = useState(null);
+
+      // Log — archive
+      const [showArchived, setShowArchived] = useState(false);
+
+      // Patterns
+      const [insight, setInsight] = useState("");
+      const [loadingInsight, setLoadingInsight] = useState(false);
+      const [insightError, setInsightError] = useState("");
+      const [showApiKeyInput, setShowApiKeyInput] = useState(false);
+      const [apiKey, setApiKey] = useState(() => localStorage.getItem(API_KEY_STORAGE) || "");
+
+      const nightTextareaRef = useRef(null);
+
+      useEffect(() => {
+        if (view === "tonight" && nightTextareaRef.current) nightTextareaRef.current.focus();
+      }, [view]);
+
+      // Load morning state if the most recent active entry already has a morning log
+      const activeEntries = entries.filter(e => !e.deleted);
+      const mostRecent = activeEntries[0] || null;
+
+      useEffect(() => {
+        if (mostRecent?.morningLog && !morningEditing) {
+          setMorning({ ...blankMorning(), ...mostRecent.morningLog });
+        }
+      }, [mostRecent?.id]);
+
+      // ── Tonight ──────────────────────────────────────────────
+      const saveNight = () => {
+        if (!nightInput.trim()) return;
+        const entry = {
+          id: Date.now(),
+          ts: new Date().toISOString(),
+          text: nightInput.trim(),
+          history: [],
+        };
+        const next = [entry, ...entries];
+        setEntries(next);
+        persistEntries(next);
+        setNightInput("");
+        setNightSaved(true);
+        setTimeout(() => setNightSaved(false), 2000);
+      };
+
+      // ── Morning ───────────────────────────────────────────────
+      const toggleCategory = (cat) => {
+        setMorning(m => ({
+          ...m,
+          categories: m.categories.includes(cat)
+            ? m.categories.filter(c => c !== cat)
+            : [...m.categories, cat]
+        }));
+      };
+
+      const addCustomTag = () => {
+        const tag = customTag.trim();
+        if (!tag || morning.categories.includes(tag)) { setCustomTag(""); return; }
+        setMorning(m => ({ ...m, categories: [...m.categories, tag] }));
+        setCustomTag("");
+      };
+
+      const saveMorning = () => {
+        if (!mostRecent) return;
+        const log = { ...morning, ts: new Date().toISOString() };
+        const next = entries.map(e =>
+          e.id === mostRecent.id ? { ...e, morningLog: log } : e
+        );
+        setEntries(next);
+        persistEntries(next);
+        setMorningSaved(true);
+        setMorningEditing(false);
+        setTimeout(() => setMorningSaved(false), 2000);
+      };
+
+      // ── Log — edit ────────────────────────────────────────────
+      const startEdit = (entry) => {
+        setEditingId(entry.id);
+        setEditDraft(entry.text);
+        setExpandedHistory(null);
+      };
+
+      const cancelEdit = () => { setEditingId(null); setEditDraft(""); };
+
+      const confirmEdit = (entry) => {
+        if (!editDraft.trim() || editDraft.trim() === entry.text) { cancelEdit(); return; }
+        const now = new Date().toISOString();
+        const historyEntry = { text: entry.text, ts: entry.editedTs || entry.ts };
+        const next = entries.map(e =>
+          e.id === entry.id
+            ? { ...e, text: editDraft.trim(), editedTs: now, history: [...(e.history || []), historyEntry] }
+            : e
+        );
+        setEntries(next);
+        persistEntries(next);
+        cancelEdit();
+      };
+
+      // ── Log — history ─────────────────────────────────────────
+      const restoreVersion = (entry, histIdx) => {
+        const version = entry.history[histIdx];
+        const now = new Date().toISOString();
+        const historyEntry = { text: entry.text, ts: entry.editedTs || entry.ts };
+        const newHistory = [...(entry.history || [])];
+        newHistory.splice(histIdx, 1);
+        newHistory.push(historyEntry);
+        const next = entries.map(e =>
+          e.id === entry.id
+            ? { ...e, text: version.text, editedTs: now, history: newHistory }
+            : e
+        );
+        setEntries(next);
+        persistEntries(next);
+        setExpandedHistory(null);
+      };
+
+      // ── Log — archive / restore ───────────────────────────────
+      const archiveEntry = (id) => {
+        const next = entries.map(e =>
+          e.id === id ? { ...e, deleted: true, deletedAt: new Date().toISOString() } : e
+        );
+        setEntries(next);
+        persistEntries(next);
+      };
+
+      const restoreEntry = (id) => {
+        const next = entries.map(e =>
+          e.id === id ? { ...e, deleted: false, deletedAt: undefined } : e
+        );
+        setEntries(next);
+        persistEntries(next);
+      };
+
+      // ── Patterns ──────────────────────────────────────────────
+      const saveApiKey = (k) => { setApiKey(k); localStorage.setItem(API_KEY_STORAGE, k); };
+
+      const getInsight = async () => {
+        const visible = entries.filter(e => !e.deleted);
+        if (visible.length < 3) return;
+        if (!apiKey.trim()) { setShowApiKeyInput(true); setInsightError("Enter your Anthropic API key above to enable pattern analysis."); return; }
+        setLoadingInsight(true); setInsight(""); setInsightError("");
+        try {
+          const log = visible.slice(0, 20).map((e, i) => {
+            let line = `${i + 1}. [Night ${formatShortDate(e.ts)}] ${e.text}`;
+            if (e.morningLog) {
+              line += `\n   [Morning ${formatShortDate(e.morningLog.ts)}] Woke thinking: "${e.morningLog.wakingThoughts}"`;
+              if (e.morningLog.categories.length) line += ` | Categories: ${e.morningLog.categories.join(", ")}`;
+              if (e.morningLog.ideas) line += `\n   Ideas: "${e.morningLog.ideas}"`;
+            }
+            return line;
+          }).join("\n\n");
+
+          const res = await fetch("https://api.anthropic.com/v1/messages", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-api-key": apiKey.trim(),
+              "anthropic-version": "2023-06-01",
+              "anthropic-dangerous-direct-browser-access": "true",
+            },
+            body: JSON.stringify({
+              model: "claude-haiku-4-5-20251001",
+              max_tokens: 350,
+              messages: [{
+                role: "user",
+                content: `Here are my recent nightly focus entries and, where captured, what I was thinking about the next morning:\n\n${log}\n\nIn 2-3 sentences: what patterns do you notice across both the evening intentions and the morning thoughts? What does this suggest about where my attention actually lives?`
+              }]
+            })
+          });
+          if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.error?.message || `HTTP ${res.status}`); }
+          const data = await res.json();
+          setInsight(data.content[0].text);
+        } catch (e) { setInsightError(`Error: ${e.message}`); }
+        setLoadingInsight(false);
+      };
+
+      // ── Derived ───────────────────────────────────────────────
+      const archivedEntries = entries.filter(e => e.deleted);
+      const today = new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" });
+      const morningHasContent = morning.wakingThoughts.trim() || morning.ideas.trim() || morning.categories.length > 0;
+      const mostRecentHasMorning = mostRecent?.morningLog && !morningEditing;
+
+      // ── Render ────────────────────────────────────────────────
+      return (
+        <div style={{ minHeight: "100vh", background: "#0d0d0d", color: "#e8e4d9", fontFamily: "'IBM Plex Mono', 'Courier New', monospace", display: "flex", flexDirection: "column", alignItems: "center", padding: "48px 24px 100px" }}>
+          <div style={{ width: "100%", maxWidth: 560 }}>
+
+            {/* Header */}
+            <div style={{ marginBottom: 40 }}>
+              <div style={{ fontSize: 10, letterSpacing: "0.2em", color: "#666", textTransform: "uppercase", marginBottom: 8 }}>
+                Diffuse Mode Solutioning
+              </div>
+              <div style={{ fontSize: 13, color: "#777" }}>{today}</div>
+            </div>
+
+            {/* Tabs */}
+            <div style={{ display: "flex", gap: 28, marginBottom: 36, borderBottom: "1px solid #1a1a1a" }}>
+              {[["tonight", "Tonight"], ["morning", "Morning"], ["log", `Log${activeEntries.length > 0 ? ` (${activeEntries.length})` : ""}`]].map(([id, label]) => (
+                <div key={id} className={`tab ${view === id ? "active" : ""}`} onClick={() => setView(id)}>{label}</div>
+              ))}
+            </div>
+
+            {/* ── TONIGHT ── */}
+            {view === "tonight" && (
+              <div style={{ animation: "fi 0.3s ease" }}>
+                <div style={{ fontSize: 17, lineHeight: 1.65, color: "#c8c4b8", marginBottom: 32, fontWeight: 300 }}>
+                  {NIGHT_PROMPT}
+                </div>
+                <textarea
+                  ref={nightTextareaRef}
+                  className="text-area"
+                  value={nightInput}
+                  onChange={e => setNightInput(e.target.value)}
+                  onKeyDown={e => { if ((e.metaKey || e.ctrlKey) && e.key === "Enter") saveNight(); }}
+                  placeholder="Write it out..."
+                  rows={5}
+                  style={{ marginBottom: 20 }}
+                />
+                <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+                  <button className="save-btn" onClick={saveNight} disabled={!nightInput.trim()}>
+                    {nightSaved ? "✓ Saved" : "Save"}
+                  </button>
+                  <span style={{ fontSize: 10, color: "#555", letterSpacing: "0.08em" }}>⌘ + Enter</span>
+                </div>
+
+                {mostRecent && (
+                  <div style={{ marginTop: 48, paddingTop: 24, borderTop: "1px solid #1a1a1a" }}>
+                    <div className="field-label">Last entry</div>
+                    <div style={{ fontSize: 11, color: "#666", marginBottom: 6 }}>{formatDate(mostRecent.ts)} · {formatTime(mostRecent.ts)}</div>
+                    <div style={{ fontSize: 13, color: "#888", lineHeight: 1.7 }}>{mostRecent.text}</div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── MORNING ── */}
+            {view === "morning" && (
+              <div style={{ animation: "fi 0.3s ease" }}>
+                {!mostRecent ? (
+                  <div style={{ color: "#666", fontSize: 13 }}>No focus entry yet. Set tonight's focus first.</div>
+                ) : (
+                  <>
+                    {/* Context bar */}
+                    <div style={{ marginBottom: 32, padding: "12px 16px", background: "#0f0f0f", borderLeft: "2px solid #1e1e1e" }}>
+                      <div className="field-label" style={{ marginBottom: 6 }}>Last night's focus</div>
+                      <div style={{ fontSize: 13, color: "#888", lineHeight: 1.6 }}>{mostRecent.text}</div>
+                    </div>
+
+                    {mostRecentHasMorning ? (
+                      /* Read mode */
+                      <div>
+                        <div style={{ marginBottom: 24 }}>
+                          <div className="field-label">Waking thoughts</div>
+                          <div style={{ fontSize: 13, color: "#888", lineHeight: 1.7 }}>{mostRecent.morningLog.wakingThoughts || <span style={{ color: "#555" }}>—</span>}</div>
+                        </div>
+                        {mostRecent.morningLog.categories.length > 0 && (
+                          <div style={{ marginBottom: 24 }}>
+                            <div className="field-label">Categories</div>
+                            <div style={{ display: "flex", flexWrap: "wrap" }}>
+                              {mostRecent.morningLog.categories.map(c => (
+                                <span key={c} className="chip selected" style={{ cursor: "default" }}>{c}</span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {mostRecent.morningLog.ideas && (
+                          <div style={{ marginBottom: 24 }}>
+                            <div className="field-label">Ideas captured</div>
+                            <div style={{ fontSize: 13, color: "#888", lineHeight: 1.7 }}>{mostRecent.morningLog.ideas}</div>
+                          </div>
+                        )}
+                        <div style={{ marginBottom: 28 }}>
+                          <div className="field-label">Related to focus</div>
+                          <div style={{ fontSize: 13, color: mostRecent.morningLog.relatedToFocus ? "#888" : "#666" }}>
+                            {mostRecent.morningLog.relatedToFocus ? "Yes" : "No"}
+                          </div>
+                        </div>
+                        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+                          <div style={{ fontSize: 10, color: "#555", letterSpacing: "0.08em" }}>
+                            logged {formatTime(mostRecent.morningLog.ts)}
+                          </div>
+                          <button className="ghost-btn" onClick={() => { setMorning({ ...blankMorning(), ...mostRecent.morningLog }); setMorningEditing(true); }}>
+                            Edit
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      /* Edit / entry mode */
+                      <>
+                        <div style={{ marginBottom: 24 }}>
+                          <div className="field-label">What were you thinking about when you woke up?</div>
+                          <textarea
+                            className="text-area"
+                            value={morning.wakingThoughts}
+                            onChange={e => setMorning(m => ({ ...m, wakingThoughts: e.target.value }))}
+                            placeholder="Describe what was on your mind..."
+                            rows={4}
+                          />
+                        </div>
+
+                        <div style={{ marginBottom: 24 }}>
+                          <div className="field-label">Categories</div>
+                          <div style={{ display: "flex", flexWrap: "wrap", marginBottom: 8 }}>
+                            {CATEGORIES.map(cat => (
+                              <div key={cat} className={`chip ${morning.categories.includes(cat) ? "selected" : ""}`} onClick={() => toggleCategory(cat)}>
+                                {cat}
+                              </div>
+                            ))}
+                            {morning.categories.filter(c => !CATEGORIES.includes(c)).map(c => (
+                              <div key={c} className="chip selected" onClick={() => toggleCategory(c)}>{c} ×</div>
+                            ))}
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                            <input
+                              className="tag-input"
+                              value={customTag}
+                              onChange={e => setCustomTag(e.target.value)}
+                              onKeyDown={e => { if (e.key === "Enter") addCustomTag(); }}
+                              placeholder="+ custom tag"
+                            />
+                          </div>
+                        </div>
+
+                        <div style={{ marginBottom: 24 }}>
+                          <div className="field-label">Thoughts or ideas to capture</div>
+                          <textarea
+                            className="text-area"
+                            value={morning.ideas}
+                            onChange={e => setMorning(m => ({ ...m, ideas: e.target.value }))}
+                            placeholder="Any ideas, threads, or insights that surfaced..."
+                            rows={4}
+                          />
+                        </div>
+
+                        <div style={{ marginBottom: 32 }}>
+                          <div className="toggle-row" onClick={() => setMorning(m => ({ ...m, relatedToFocus: !m.relatedToFocus }))}>
+                            <div className={`toggle-box ${morning.relatedToFocus ? "checked" : ""}`} />
+                            <span style={{ fontSize: 12, color: morning.relatedToFocus ? "#c8c4b8" : "#777", letterSpacing: "0.04em" }}>
+                              Related to last night's focus
+                            </span>
+                          </div>
+                        </div>
+
+                        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+                          <button className="save-btn" onClick={saveMorning} disabled={!morningHasContent}>
+                            {morningSaved ? "✓ Saved" : "Save morning log"}
+                          </button>
+                          {morningEditing && (
+                            <button className="ghost-btn" onClick={() => { setMorningEditing(false); setMorning({ ...blankMorning(), ...mostRecent.morningLog }); }}>
+                              Cancel
+                            </button>
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* ── LOG ── */}
+            {view === "log" && (
+              <div style={{ animation: "fi 0.3s ease" }}>
+                {activeEntries.length === 0 && archivedEntries.length === 0 ? (
+                  <div style={{ color: "#666", fontSize: 13 }}>No entries yet.</div>
+                ) : (
+                  <>
+                    {activeEntries.map(entry => (
+                      <div key={entry.id} className="entry">
+                        {/* Entry header */}
+                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10 }}>
+                          <div style={{ fontSize: 10, color: "#555", letterSpacing: "0.1em" }}>
+                            {formatDate(entry.ts)} · {formatTime(entry.ts)}
+                            {entry.editedTs && <span style={{ color: "#555" }}> · edited {formatTime(entry.editedTs)}</span>}
+                          </div>
+                          <div style={{ display: "flex", gap: 14, flexShrink: 0, marginLeft: 12 }}>
+                            {editingId !== entry.id && (
+                              <>
+                                <button className="ghost-btn accent" onClick={() => startEdit(entry)}>Edit</button>
+                                <button className="ghost-btn danger" onClick={() => archiveEntry(entry.id)}>Archive</button>
+                              </>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Entry text or edit textarea */}
+                        {editingId === entry.id ? (
+                          <div>
+                            <textarea
+                              className="text-area"
+                              value={editDraft}
+                              onChange={e => setEditDraft(e.target.value)}
+                              rows={4}
+                              style={{ marginBottom: 12 }}
+                              autoFocus
+                            />
+                            <div style={{ display: "flex", gap: 14 }}>
+                              <button className="save-btn" style={{ padding: "8px 20px", fontSize: 11 }} onClick={() => confirmEdit(entry)} disabled={!editDraft.trim()}>Save</button>
+                              <button className="ghost-btn" onClick={cancelEdit}>Cancel</button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div style={{ fontSize: 13, lineHeight: 1.75, color: "#a8a49a" }}>{entry.text}</div>
+                        )}
+
+                        {/* Morning log block */}
+                        {entry.morningLog && editingId !== entry.id && (
+                          <div className="morning-block">
+                            <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.1em", marginBottom: 8 }}>
+                              Morning · {formatTime(entry.morningLog.ts)}
+                            </div>
+                            {entry.morningLog.wakingThoughts && (
+                              <div style={{ fontSize: 12, color: "#666", lineHeight: 1.7, marginBottom: 6 }}>
+                                "{entry.morningLog.wakingThoughts}"
+                              </div>
+                            )}
+                            {entry.morningLog.categories.length > 0 && (
+                              <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.06em", marginBottom: 4 }}>
+                                {entry.morningLog.categories.join(" · ")}
+                              </div>
+                            )}
+                            {entry.morningLog.ideas && (
+                              <div style={{ fontSize: 12, color: "#555", lineHeight: 1.65, marginTop: 6, fontStyle: "italic" }}>
+                                {entry.morningLog.ideas}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* History */}
+                        {entry.history?.length > 0 && editingId !== entry.id && (
+                          <div style={{ marginTop: 12 }}>
+                            <button
+                              className="inline-btn"
+                              onClick={() => setExpandedHistory(expandedHistory === entry.id ? null : entry.id)}
+                            >
+                              {expandedHistory === entry.id ? "▾" : "▸"} History ({entry.history.length})
+                            </button>
+                            {expandedHistory === entry.id && (
+                              <div style={{ marginTop: 10, paddingLeft: 10, borderLeft: "1px solid #1a1a1a", animation: "fi 0.2s ease" }}>
+                                {[...entry.history].reverse().map((h, i) => {
+                                  const realIdx = entry.history.length - 1 - i;
+                                  return (
+                                    <div key={i} className="history-item">
+                                      <div style={{ flex: 1 }}>
+                                        <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.08em", marginBottom: 4 }}>
+                                          v{realIdx + 1} · {formatDate(h.ts)} · {formatTime(h.ts)}
+                                        </div>
+                                        <div style={{ fontSize: 12, color: "#888", lineHeight: 1.6 }}>{h.text}</div>
+                                      </div>
+                                      <button className="ghost-btn accent" style={{ flexShrink: 0 }} onClick={() => restoreVersion(entry, realIdx)}>
+                                        Restore
+                                      </button>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+
+                    {/* Archived section */}
+                    {archivedEntries.length > 0 && (
+                      <div style={{ marginTop: 24 }}>
+                        <button className="ghost-btn" onClick={() => setShowArchived(s => !s)} style={{ marginBottom: 16 }}>
+                          {showArchived ? "▾" : "▸"} Archived ({archivedEntries.length})
+                        </button>
+                        {showArchived && archivedEntries.map(entry => (
+                          <div key={entry.id} className="entry archived">
+                            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10 }}>
+                              <div style={{ fontSize: 10, color: "#555", letterSpacing: "0.1em" }}>
+                                {formatDate(entry.ts)} · {formatTime(entry.ts)}
+                                {entry.deletedAt && <span> · archived {formatShortDate(entry.deletedAt)}</span>}
+                              </div>
+                              <button className="ghost-btn accent" onClick={() => restoreEntry(entry.id)}>Restore</button>
+                            </div>
+                            <div style={{ fontSize: 13, lineHeight: 1.75, color: "#555" }}>{entry.text}</div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Pattern analysis */}
+                    {activeEntries.length >= 3 && (
+                      <div style={{ marginTop: 40, paddingTop: 28, borderTop: "1px solid #161616" }}>
+                        {showApiKeyInput && (
+                          <div style={{ marginBottom: 16 }}>
+                            <div className="field-label">Anthropic API Key</div>
+                            <input className="key-input" type="password" value={apiKey} onChange={e => saveApiKey(e.target.value)} placeholder="sk-ant-..." spellCheck={false} />
+                            <div style={{ fontSize: 10, color: "#555", marginTop: 6 }}>Stored locally. Never sent anywhere except Anthropic.</div>
+                          </div>
+                        )}
+                        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+                          <button className="insight-btn" onClick={getInsight} disabled={loadingInsight}>
+                            {loadingInsight ? "Analyzing..." : "→ Find patterns"}
+                          </button>
+                          {!showApiKeyInput && (
+                            <button className="ghost-btn" onClick={() => setShowApiKeyInput(true)}>API key</button>
+                          )}
+                        </div>
+                        {insightError && <div style={{ marginTop: 14, fontSize: 12, color: "#5a3a3a", lineHeight: 1.6 }}>{insightError}</div>}
+                        {insight && (
+                          <div style={{ marginTop: 20, padding: 16, background: "#111", border: "1px solid #1a1a1a", fontSize: 13, lineHeight: 1.85, color: "#777", animation: "fi 0.4s ease" }}>
+                            {insight}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {activeEntries.length < 3 && activeEntries.length > 0 && (
+                      <div style={{ marginTop: 28, fontSize: 10, color: "#555", letterSpacing: "0.06em" }}>
+                        {3 - activeEntries.length} more {3 - activeEntries.length === 1 ? "entry" : "entries"} until pattern analysis unlocks.
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Raises near-invisible colors (#3a3a3a, #2e2e2e, #252525) to legible values (#555–#777) throughout the app while preserving the dark aesthetic.

Affected elements: field labels, timestamps, tab bar, category chips, ghost buttons, morning block metadata, history version dates, and all secondary text.