### PR TITLE
Add pattern history, token/cost tracking, and time box filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,9 @@
     .key-input:focus { border-color: #333; }
 
     .morning-block { margin-top: 14px; padding: 12px 14px; background: #0f0f0f; border-left: 1px solid #1e1e1e; animation: fi 0.3s ease; }
+
+    .datetime-input { background: #111; border: 1px solid #1e1e1e; color: #777; font-family: 'IBM Plex Mono', monospace; font-size: 11px; padding: 6px 10px; letter-spacing: 0.04em; color-scheme: dark; }
+    .datetime-input:focus { border-color: #333; outline: none; }
   </style>
 </head>
 <body>
@@ -124,6 +127,11 @@
       if (usd < 0.0001) return "<$0.0001";
       return `$${usd.toFixed(4)}`;
     }
+    function toDatetimeLocal(iso) {
+      const d = new Date(iso);
+      const pad = n => String(n).padStart(2, "0");
+      return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
 
     function loadEntries() {
       try {
@@ -160,14 +168,15 @@
       const [wakingCustomTag, setWakingCustomTag] = useState("");
       const [wakingSaved, setWakingSaved] = useState(false);
 
-      // Log — category editing
-      const [editingLogCat, setEditingLogCat] = useState(null); // { entryId, wakingId }
-      const [logCatDraft, setLogCatDraft] = useState([]);
-      const [logCatCustomTag, setLogCatCustomTag] = useState("");
+      // Log — waking edit (full: text, categories, ideas, datetime)
+      const [editingLogWaking, setEditingLogWaking] = useState(null); // { entryId, wakingId }
+      const [logWakingDraft, setLogWakingDraft] = useState(null);
+      const [logWakingCustomTag, setLogWakingCustomTag] = useState("");
 
-      // Log — edit
+      // Log — night entry edit
       const [editingId, setEditingId] = useState(null);
       const [editDraft, setEditDraft] = useState("");
+      const [editDatetime, setEditDatetime] = useState("");
 
       // Log — history
       const [expandedHistory, setExpandedHistory] = useState(null);
@@ -262,56 +271,64 @@
         setTimeout(() => setWakingSaved(false), 2000);
       };
 
-      // ── Log — category editing ────────────────────────────────
-      const startLogCatEdit = (entryId, w) => {
-        setEditingLogCat({ entryId, wakingId: w.id });
-        setLogCatDraft([...w.categories]);
-        setLogCatCustomTag("");
+      // ── Log — waking edit ────────────────────────────────────
+      const startLogWakingEdit = (entryId, w) => {
+        setEditingLogWaking({ entryId, wakingId: w.id });
+        setLogWakingDraft({ wakingThoughts: w.wakingThoughts || "", categories: [...w.categories], ideas: w.ideas || "", relatedToFocus: w.relatedToFocus || false, ts: toDatetimeLocal(w.ts) });
+        setLogWakingCustomTag("");
       };
 
-      const cancelLogCatEdit = () => { setEditingLogCat(null); setLogCatDraft([]); setLogCatCustomTag(""); };
+      const cancelLogWakingEdit = () => { setEditingLogWaking(null); setLogWakingDraft(null); setLogWakingCustomTag(""); };
 
-      const toggleLogCat = (cat) => {
-        setLogCatDraft(d => d.includes(cat) ? d.filter(c => c !== cat) : [...d, cat]);
+      const toggleLogWakingCat = (cat) => {
+        setLogWakingDraft(d => ({ ...d, categories: d.categories.includes(cat) ? d.categories.filter(c => c !== cat) : [...d.categories, cat] }));
       };
 
-      const addLogCatCustomTag = () => {
-        const tag = logCatCustomTag.trim();
-        if (!tag || logCatDraft.includes(tag)) { setLogCatCustomTag(""); return; }
-        setLogCatDraft(d => [...d, tag]);
-        setLogCatCustomTag("");
+      const addLogWakingCustomTag = () => {
+        const tag = logWakingCustomTag.trim();
+        if (!tag || logWakingDraft.categories.includes(tag)) { setLogWakingCustomTag(""); return; }
+        setLogWakingDraft(d => ({ ...d, categories: [...d.categories, tag] }));
+        setLogWakingCustomTag("");
       };
 
-      const saveLogCat = () => {
-        if (!editingLogCat) return;
-        const { entryId, wakingId } = editingLogCat;
+      const saveLogWaking = () => {
+        if (!editingLogWaking) return;
+        const { entryId, wakingId } = editingLogWaking;
         const next = entries.map(e => {
           if (e.id !== entryId) return e;
           const logs = getMorningLogs(e);
-          const updated = logs.map(w => w.id === wakingId ? { ...w, categories: logCatDraft } : w);
+          const updated = logs.map(w => {
+            if (w.id !== wakingId) return w;
+            const newTs = logWakingDraft.ts ? new Date(logWakingDraft.ts).toISOString() : w.ts;
+            return { ...w, wakingThoughts: logWakingDraft.wakingThoughts, categories: logWakingDraft.categories, ideas: logWakingDraft.ideas, relatedToFocus: logWakingDraft.relatedToFocus, ts: newTs };
+          });
           return { ...e, morningLogs: updated };
         });
         setEntries(next);
         persistEntries(next);
-        cancelLogCatEdit();
+        cancelLogWakingEdit();
       };
 
       // ── Log — edit ────────────────────────────────────────────
       const startEdit = (entry) => {
         setEditingId(entry.id);
         setEditDraft(entry.text);
+        setEditDatetime(toDatetimeLocal(entry.ts));
         setExpandedHistory(null);
       };
 
-      const cancelEdit = () => { setEditingId(null); setEditDraft(""); };
+      const cancelEdit = () => { setEditingId(null); setEditDraft(""); setEditDatetime(""); };
 
       const confirmEdit = (entry) => {
-        if (!editDraft.trim() || editDraft.trim() === entry.text) { cancelEdit(); return; }
+        const newText = editDraft.trim();
+        if (!newText) { cancelEdit(); return; }
+        const newTs = editDatetime ? new Date(editDatetime).toISOString() : entry.ts;
+        if (newText === entry.text && newTs === entry.ts) { cancelEdit(); return; }
         const now = new Date().toISOString();
         const historyEntry = { text: entry.text, ts: entry.editedTs || entry.ts };
         const next = entries.map(e =>
           e.id === entry.id
-            ? { ...e, text: editDraft.trim(), editedTs: now, history: [...(e.history || []), historyEntry] }
+            ? { ...e, text: newText, ts: newTs, editedTs: now, history: [...(e.history || []), historyEntry] }
             : e
         );
         setEntries(next);
@@ -423,6 +440,9 @@
       const timeBoxStart = getTimeBoxStart(patternTimeBox);
       const timeBoxEntries = timeBoxStart ? activeEntries.filter(e => new Date(e.ts) >= timeBoxStart) : activeEntries;
       const totalCostUsd = patternHistory.reduce((sum, r) => sum + (r.usage?.costUsd ?? 0), 0);
+      const allCustomCategories = [...new Set(
+        activeEntries.flatMap(e => getMorningLogs(e).flatMap(w => w.categories.filter(c => !CATEGORIES.includes(c))))
+      )];
 
       // ── Render ────────────────────────────────────────────────
       return (
@@ -511,6 +531,9 @@
                                 ))}
                                 {wakingDraft.categories.filter(c => !CATEGORIES.includes(c)).map(c => (
                                   <div key={c} className="chip selected" onClick={() => toggleWakingCategory(c)}>{c} ×</div>
+                                ))}
+                                {allCustomCategories.filter(c => !wakingDraft.categories.includes(c)).map(c => (
+                                  <div key={c} className="chip" onClick={() => toggleWakingCategory(c)}>{c}</div>
                                 ))}
                               </div>
                               <input className="tag-input" value={wakingCustomTag} onChange={e => setWakingCustomTag(e.target.value)} onKeyDown={e => { if (e.key === "Enter") addWakingCustomTag(); }} placeholder="+ custom tag" />
@@ -634,9 +657,13 @@
                               value={editDraft}
                               onChange={e => setEditDraft(e.target.value)}
                               rows={4}
-                              style={{ marginBottom: 12 }}
+                              style={{ marginBottom: 10 }}
                               autoFocus
                             />
+                            <div style={{ marginBottom: 12 }}>
+                              <div className="field-label" style={{ marginBottom: 4 }}>Date</div>
+                              <input type="datetime-local" className="datetime-input" value={editDatetime} onChange={e => setEditDatetime(e.target.value)} />
+                            </div>
                             <div style={{ display: "flex", gap: 14 }}>
                               <button className="save-btn" style={{ padding: "8px 20px", fontSize: 11 }} onClick={() => confirmEdit(entry)} disabled={!editDraft.trim()}>Save</button>
                               <button className="ghost-btn" onClick={cancelEdit}>Cancel</button>
@@ -648,48 +675,70 @@
 
                         {/* Morning waking log blocks */}
                         {getMorningLogs(entry).length > 0 && editingId !== entry.id && getMorningLogs(entry).map((w, wi) => {
-                          const isEditingCat = editingLogCat?.entryId === entry.id && editingLogCat?.wakingId === w.id;
+                          const isEditingWaking = editingLogWaking?.entryId === entry.id && editingLogWaking?.wakingId === w.id;
                           const wLogs = getMorningLogs(entry);
                           return (
                             <div key={w.id} className="morning-block">
-                              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 6 }}>
-                                <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.1em" }}>
-                                  {wLogs.length > 1 ? `Waking ${wi + 1} · ` : "Morning · "}{formatTime(w.ts)}
-                                </div>
-                                {!isEditingCat && !editingLogCat && (
-                                  <button className="ghost-btn" onClick={() => startLogCatEdit(entry.id, w)}>Edit categories</button>
-                                )}
-                              </div>
-                              {w.wakingThoughts && (
-                                <div style={{ fontSize: 12, color: "#666", lineHeight: 1.7, marginBottom: 6 }}>"{w.wakingThoughts}"</div>
-                              )}
-                              {isEditingCat ? (
-                                <div style={{ marginTop: 8 }}>
-                                  <div style={{ display: "flex", flexWrap: "wrap", marginBottom: 6 }}>
-                                    {CATEGORIES.map(cat => (
-                                      <div key={cat} className={`chip ${logCatDraft.includes(cat) ? "selected" : ""}`} onClick={() => toggleLogCat(cat)}>{cat}</div>
-                                    ))}
-                                    {logCatDraft.filter(c => !CATEGORIES.includes(c)).map(c => (
-                                      <div key={c} className="chip selected" onClick={() => toggleLogCat(c)}>{c} ×</div>
-                                    ))}
+                              {isEditingWaking ? (
+                                <div style={{ animation: "fi 0.2s ease" }}>
+                                  <div style={{ fontSize: 10, color: "#555", letterSpacing: "0.1em", marginBottom: 14 }}>
+                                    {wLogs.length > 1 ? `Waking ${wi + 1} · ` : ""}editing
                                   </div>
-                                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
-                                    <input className="tag-input" value={logCatCustomTag} onChange={e => setLogCatCustomTag(e.target.value)} onKeyDown={e => { if (e.key === "Enter") addLogCatCustomTag(); }} placeholder="+ custom tag" />
+                                  <div style={{ marginBottom: 14 }}>
+                                    <div className="field-label">Waking thoughts</div>
+                                    <textarea className="text-area" value={logWakingDraft.wakingThoughts} onChange={e => setLogWakingDraft(d => ({ ...d, wakingThoughts: e.target.value }))} rows={3} autoFocus />
+                                  </div>
+                                  <div style={{ marginBottom: 14 }}>
+                                    <div className="field-label">Categories</div>
+                                    <div style={{ display: "flex", flexWrap: "wrap", marginBottom: 6 }}>
+                                      {CATEGORIES.map(cat => (
+                                        <div key={cat} className={`chip ${logWakingDraft.categories.includes(cat) ? "selected" : ""}`} onClick={() => toggleLogWakingCat(cat)}>{cat}</div>
+                                      ))}
+                                      {logWakingDraft.categories.filter(c => !CATEGORIES.includes(c)).map(c => (
+                                        <div key={c} className="chip selected" onClick={() => toggleLogWakingCat(c)}>{c} ×</div>
+                                      ))}
+                                      {allCustomCategories.filter(c => !logWakingDraft.categories.includes(c)).map(c => (
+                                        <div key={c} className="chip" onClick={() => toggleLogWakingCat(c)}>{c}</div>
+                                      ))}
+                                    </div>
+                                    <input className="tag-input" value={logWakingCustomTag} onChange={e => setLogWakingCustomTag(e.target.value)} onKeyDown={e => { if (e.key === "Enter") addLogWakingCustomTag(); }} placeholder="+ custom tag" />
+                                  </div>
+                                  <div style={{ marginBottom: 14 }}>
+                                    <div className="field-label">Ideas</div>
+                                    <textarea className="text-area" value={logWakingDraft.ideas} onChange={e => setLogWakingDraft(d => ({ ...d, ideas: e.target.value }))} rows={3} />
+                                  </div>
+                                  <div style={{ marginBottom: 14 }}>
+                                    <div className="field-label">Date & time</div>
+                                    <input type="datetime-local" className="datetime-input" value={logWakingDraft.ts} onChange={e => setLogWakingDraft(d => ({ ...d, ts: e.target.value }))} />
                                   </div>
                                   <div style={{ display: "flex", gap: 12 }}>
-                                    <button className="save-btn" style={{ padding: "6px 16px", fontSize: 10 }} onClick={saveLogCat}>Save</button>
-                                    <button className="ghost-btn" onClick={cancelLogCatEdit}>Cancel</button>
+                                    <button className="save-btn" style={{ padding: "6px 16px", fontSize: 10 }} onClick={saveLogWaking}>Save</button>
+                                    <button className="ghost-btn" onClick={cancelLogWakingEdit}>Cancel</button>
                                   </div>
                                 </div>
                               ) : (
-                                w.categories.length > 0 && (
-                                  <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.06em", marginBottom: 4 }}>
-                                    {w.categories.join(" · ")}
+                                <>
+                                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 6 }}>
+                                    <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.1em" }}>
+                                      {wLogs.length > 1 ? `Waking ${wi + 1} · ` : "Morning · "}{formatTime(w.ts)}
+                                    </div>
+                                    {!editingLogWaking && (
+                                      <button className="ghost-btn" onClick={() => startLogWakingEdit(entry.id, w)}>Edit</button>
+                                    )}
                                   </div>
-                                )
-                              )}
-                              {w.ideas && (
-                                <div style={{ fontSize: 12, color: "#555", lineHeight: 1.65, marginTop: 6, fontStyle: "italic" }}>{w.ideas}</div>
+                                  {w.wakingThoughts && (
+                                    <div style={{ fontSize: 12, color: "#666", lineHeight: 1.7, marginBottom: 6 }}>"{w.wakingThoughts}"</div>
+                                  )}
+                                  {w.categories.length > 0 && (
+                                    <div style={{ fontSize: 10, color: "#666", letterSpacing: "0.06em", marginBottom: 4 }}>
+                                      {w.categories.join(" · ")}
+                                    </div>
+                                  )}
+                                  {w.ideas && (
+                                    <div style={{ fontSize: 12, color: "#555", lineHeight: 1.65, marginTop: 6, fontStyle: "italic" }}>{w.ideas}</div>
+                                  )}
+                                  {w.relatedToFocus && <div style={{ fontSize: 10, color: "#555", letterSpacing: "0.06em", marginTop: 6 }}>related to focus</div>}
+                                </>
                               )}
                             </div>
                           );


### PR DESCRIPTION
- Pattern analyses are now saved to localStorage (nightly-focus-patterns-v1)
  with timestamp, time box used, entry count, insight text, and usage stats.
  Displayed in a collapsible "Pattern history" section.
- Token tracking: reads actual input/output tokens from the API response and
  computes an estimated cost (Haiku pricing: $0.80/1M in, $4/1M out).
  Shown inline below each analysis and aggregated across all-time history.
- Time box selector lets the user scope pattern input to last week, month,
  quarter, year, or all time. Entry count for the selected range is shown
  live; the Analyze button is disabled if fewer than 3 entries match.

https://claude.ai/code/session_016XgrHUfa93rBTz8BBq7wCs