### PR TITLE
Fix PR comment line breaks by instructing Claude not to hard-wrap text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Claude Code — Global Instructions
 
+## PR and issue comment formatting
+
+When writing PR descriptions, issue comments, or any GitHub-facing text body, **do not hard-wrap lines**. Write each paragraph as a single continuous line with no embedded newlines. GitHub renders bare newlines as line breaks, which causes mid-sentence breaks in the rendered output. Separate paragraphs with a blank line instead.
+
 ## After completing work on a branch
 
 At the end of every session where you've pushed commits to a branch, provide the


### PR DESCRIPTION
GitHub renders bare newlines as <br> in PR/issue bodies, causing
mid-sentence line breaks when prose is hard-wrapped at 80 chars.
Add a CLAUDE.md instruction to write paragraphs as single lines.

https://claude.ai/code/session_01JAq898QnbtqNk1QaUGLR3F