### PR TITLE
Move export data to footer and fix clear data button UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,14 +954,6 @@
                       </div>
                     ))}
 
-                    {/* Export */}
-                    {activeEntries.length > 0 && (
-                      <div style={{ marginTop: 28, display: "flex", gap: 16 }}>
-                        <button className="ghost-btn" onClick={() => exportData("txt")}>↓ Export as text</button>
-                        <button className="ghost-btn" onClick={() => exportData("json")}>↓ Export as JSON</button>
-                      </div>
-                    )}
-
                     {/* Archived section */}
                     {archivedEntries.length > 0 && (
                       <div style={{ marginTop: 24 }}>
@@ -1112,18 +1104,23 @@
               <div>Data is stored locally and never shared without your permission.</div>
               <div>'Find Patterns' sends data to Anthropic.</div>
               <div style={{ marginTop: 12 }}>
-                {!showClearConfirm ? (
-                  <button className="ghost-btn danger" style={{ fontSize: 10 }} onClick={() => setShowClearConfirm(true)}>
-                    Clear all data
-                  </button>
-                ) : (
-                  <div>
-                    <div style={{ fontSize: 11, color: "#888", marginBottom: 12 }}>
+                <span>Export data as: </span>
+                <button className="ghost-btn" style={{ fontSize: 10, display: "inline", padding: "2px 6px" }} onClick={() => exportData("txt")}>Text</button>
+                <span style={{ margin: "0 6px" }}>|</span>
+                <button className="ghost-btn" style={{ fontSize: 10, display: "inline", padding: "2px 6px" }} onClick={() => exportData("json")}>JSON</button>
+              </div>
+              <div style={{ marginTop: 12 }}>
+                <button className="ghost-btn danger" style={{ fontSize: 10 }} onClick={() => setShowClearConfirm(s => !s)}>
+                  Clear all data
+                </button>
+                {showClearConfirm && (
+                  <div style={{ marginTop: 10 }}>
+                    <div style={{ fontSize: 11, color: "#888", marginBottom: 10 }}>
                       This action cannot be undone. It will clear all data including nightly focus, waking thoughts, and API key &amp; pattern analysis results. Are you sure?
                     </div>
                     <div style={{ display: "flex", gap: 20 }}>
                       <button className="ghost-btn danger" onClick={clearAllData}>Yes</button>
-                      <button className="ghost-btn" onClick={() => setShowClearConfirm(false)}>No</button>
+                      <button className="ghost-btn" onClick={() => setShowClearConfirm(false)}>Cancel</button>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
- Remove export buttons from the Log tab
- Add "Export data as: Text | JSON" in the global footer, above clear data
- Keep "Clear all data" button always visible; show warning + yes/cancel
  below it instead of replacing it when clicked
- Clicking "Clear all data" again toggles the confirmation away (acts as cancel)

https://claude.ai/code/session_0126wTtPky7L7UGfyrF3z4Zr