### PR TITLE
Fix MCP tool failure guidance: remove broken gh CLI fallback, add proactive ToolSearch pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,16 @@ your final response before signing off.
 
 ## GitHub MCP tools — availability and retries
 
-The GitHub MCP server runs with `MCP_CONNECTION_NONBLOCKING=true`, which means the session starts before the server finishes connecting. Tools may not be available immediately. The `gh` CLI and `hub` CLI are **not** available in this environment, so there is no shell fallback.
+The GitHub MCP server runs with `MCP_CONNECTION_NONBLOCKING=true`, which means the session starts before the server finishes connecting. Tools may not be available immediately. The `gh` CLI and `hub` CLI are **not** available in this environment.
 
 **At the start of any task that needs GitHub tools**, always call ToolSearch with `"query": "mcp__github"` proactively — before you need a specific tool. This gives the MCP server time to finish connecting and surfaces the tool schemas early.
 
 **If a tool call fails or ToolSearch returns no results:**
 1. Wait a moment, then retry ToolSearch once more.
-2. If tools are still unavailable after two ToolSearch attempts, tell the user: *"The GitHub MCP server is not responding. Please start a new session and try again."* Do not keep retrying in a loop.
+2. If tools are still unavailable after two ToolSearch attempts:
+   - **For reading** an issue or PR: use `WebFetch` on the GitHub HTML URL (e.g. `https://github.com/pbannan/diffuse-mode-solutioning/issues/33`). This works for public repos and is not rate-limited like the REST API.
+   - **For writing** (commenting, closing, creating PRs): there is no authenticated shell fallback. Tell the user: *"The GitHub MCP server is not responding. Please start a new session and try again."*
+   - Do not use `curl` against `api.github.com` — unauthenticated API calls are limited to 60 requests/hour and the quota is often already exhausted.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,18 @@ your final response before signing off.
 
 ---
 
+## GitHub MCP tools — availability and retries
+
+The GitHub MCP server runs with `MCP_CONNECTION_NONBLOCKING=true`, which means the session starts before the server finishes connecting. Tools may not be available immediately. The `gh` CLI and `hub` CLI are **not** available in this environment, so there is no shell fallback.
+
+**At the start of any task that needs GitHub tools**, always call ToolSearch with `"query": "mcp__github"` proactively — before you need a specific tool. This gives the MCP server time to finish connecting and surfaces the tool schemas early.
+
+**If a tool call fails or ToolSearch returns no results:**
+1. Wait a moment, then retry ToolSearch once more.
+2. If tools are still unavailable after two ToolSearch attempts, tell the user: *"The GitHub MCP server is not responding. Please start a new session and try again."* Do not keep retrying in a loop.
+
+---
+
 ## Closing GitHub issues with the MCP tools
 
 Do **not** comment on or close an issue after pushing. There may be many
@@ -30,14 +42,7 @@ needed.
 Wait until the user explicitly asks you to close the issue. That means the
 user has tested locally, approved the PR, and is ready to wrap up.
 
-When the user asks you to close the issue, do both steps below in order.
-
-If the MCP tools appear unavailable (e.g. due to a disconnected server), do
-**not** ask the user — retry immediately using ToolSearch to load the tools
-and try again. If they are still unavailable after retrying, attempt the
-operation via the Bash tool using the `gh` CLI as a fallback (e.g.
-`gh issue comment`, `gh issue close`). Only report failure to the user after
-both methods have been attempted.
+When the user asks you to close the issue, first run ToolSearch for `"mcp__github"` to ensure the tools are loaded, then do both steps below in order. If tools remain unavailable after retrying per the instructions above, report failure to the user.
 
 ### Step 1 — Comment with a summary of final changes and root cause
 


### PR DESCRIPTION
Root cause analysis: MCP_CONNECTION_NONBLOCKING=true means tools aren't ready
at session start; gh CLI is not installed so the existing fallback never worked.

New instructions: ToolSearch for mcp__github proactively at the start of any
GitHub task, retry once on failure, then tell user to restart the session.

https://claude.ai/code/session_01WBUV6WnJoCdShEnh6Ffvuv