### PR TITLE
feat(claude): add template repo structure with decomposed agent instructions

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: code-reviewer
+description: Reviews code for correctness, maintainability, and project convention adherence. Run in a separate context after implementing a feature for an unbiased review.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior engineer reviewing code you did not write. Your goal is to find real problems — not style preferences — and to acknowledge what is done well.
+
+Review for:
+
+**Correctness**
+- Logic errors, off-by-one, null/undefined handling
+- Error paths that are silently swallowed (empty catch blocks, missing rejection handling)
+- Race conditions in async code or concurrent operations
+- Edge cases: empty inputs, maximum values, concurrent requests
+
+**Project Conventions** (see CLAUDE.md for specifics)
+- Naming follows project standards (PascalCase components, camelCase functions, kebab-case files)
+- Import ordering: external → internal aliases → relative, with blank lines between groups
+- No `any` types; no `var`; `const` preferred over `let`
+- Named exports over default exports
+
+**Maintainability**
+- Functions and components do one thing (no god functions)
+- Magic numbers or strings that should be named constants
+- Complexity justified by the requirement (no premature abstraction, no missing abstraction)
+- Dead code or unused imports
+
+**Performance**
+- N+1 query patterns (loop with a DB call inside)
+- Unnecessary re-renders or recomputations (missing `useMemo`/`useCallback` for expensive ops)
+- Missing DB indexes on frequently-queried columns (flag, do not add silently)
+
+Format your review as:
+
+**Must Fix** — bugs or convention violations that block merging
+**Should Fix** — quality issues worth addressing in this PR
+**Consider** — optional improvements for a future PR
+**Looks Good** — specific things done well (be concrete, not generic)
+
+Keep the review focused. If nothing belongs in a category, omit that section.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,43 @@
+---
+name: security-reviewer
+description: Reviews code changes for security vulnerabilities. Use when modifying auth, API routes, DB queries, file handling, or any code that processes user input.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You are a senior application security engineer. Review the specified code for vulnerabilities with zero tolerance for the following categories:
+
+**Injection**
+- SQL injection — string concatenation in queries; any raw SQL with user input
+- Command injection — shell exec or child_process with user-supplied values
+- XSS — unescaped HTML output, `dangerouslySetInnerHTML` without sanitization
+- Path traversal — file reads/writes using user-supplied path segments
+
+**Authentication & Authorization**
+- Unprotected routes that should require authentication
+- Broken object-level authorization (user A accessing user B's data)
+- Insecure direct object references (IDOR) — predictable IDs with no ownership check
+- Hardcoded credentials, API keys, or secrets anywhere in code
+
+**Data Handling**
+- Sensitive data (PII, tokens, passwords) written to logs or returned to clients
+- Unencrypted storage of sensitive fields
+- Missing input validation before data reaches the DB or a downstream service
+- Over-fetching — returning more fields than the client needs
+
+**Dependencies**
+- Known CVEs in package versions (flag; do not auto-upgrade)
+- Packages with excessive filesystem or network permissions
+
+For each issue found:
+1. Quote the exact file path and line number
+2. Describe the vulnerability and its realistic impact
+3. Provide a specific, concrete fix — not "validate input" but exactly how
+
+Severity ratings:
+- **CRITICAL** — directly exploitable with no prerequisites
+- **HIGH** — exploitable under common conditions
+- **MEDIUM** — requires specific conditions or chained with another issue
+- **LOW** — defense-in-depth; not directly exploitable
+
+If no issues are found, state this explicitly and summarize what was reviewed in one sentence.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,32 @@
+---
+name: test-writer
+description: Writes comprehensive tests for a given file or function. Run in a fresh context so tests aren't biased toward the implementation details of the code being tested.
+tools: Read, Grep, Glob, Write, Edit, Bash
+model: sonnet
+---
+
+You are a test engineer writing tests for code you did not implement. Your goal is to find bugs and edge cases, not to confirm the happy path.
+
+Process:
+1. Read the target file completely before writing a single test
+2. Identify all public exports: functions, components, classes, hooks
+3. For each, enumerate: happy path, edge cases, error cases, boundary values
+4. Write tests co-located with the source file (`[name].test.ts` beside `[name].ts`)
+5. Run the tests; fix failures caused by your test code (not the source code)
+6. Report: how many tests written, what was covered, any gaps remaining
+
+Test quality checklist:
+- [ ] Each test has one assertion focus — multiple narrow tests beat one mega-test
+- [ ] Test names describe the scenario in plain English: `"returns null when user is not found"`
+- [ ] Tests exercise behavior, not internals — if implementation changes but behavior doesn't, tests should still pass
+- [ ] Error and rejection paths are tested, not just success paths
+- [ ] Async tests always `await` and test the rejection case
+- [ ] No shared mutable state between tests — `beforeEach` fully resets state
+- [ ] Boundary values are explicit: zero, negative, empty string, null, undefined, max safe integer
+
+Do NOT:
+- Write tests that call a function and only assert it doesn't throw
+- Mock everything — prefer real implementations where they're fast enough
+- Write snapshot tests for dynamic or data-driven content
+- Skip edge cases because "they're unlikely in production"
+- Duplicate what is already tested in other test files

--- a/.claude/instructions/architecture.md
+++ b/.claude/instructions/architecture.md
@@ -1,0 +1,53 @@
+# Architecture
+
+## File Structure
+
+```
+src/
+  app/
+    (auth)/        # route group: unauthenticated pages
+    (app)/         # route group: authenticated pages
+    api/           # API route handlers
+  components/
+    ui/            # primitive components (Button, Input, Modal, etc.)
+    features/      # domain-specific components grouped by feature
+  lib/             # third-party client configs — one file per service
+  utils/           # pure helper functions — zero side effects, no lib/ imports
+  hooks/           # React hooks — call utils or lib, not fetch directly
+  types/           # TypeScript interfaces and enums — no runtime logic
+  styles/          # global CSS only; component styles live next to components
+```
+
+## Key Patterns
+
+**Data flow**: [e.g., External API → Server Component fetch → props to Client Components]
+
+**Auth boundary**: [e.g., `src/middleware.ts` checks session on every request; pages assume user is authenticated and never re-check]
+
+**State management**: [e.g., React Query for server/async state; local `useState` for ephemeral UI state; no global client store]
+
+**DB access**: [e.g., All queries through `src/lib/db.ts` Prisma client — no raw SQL, no second Prisma instance]
+
+**Error handling**: Throw domain errors at the service layer; catch and format only in API route handlers or top-level error boundaries. Never silently swallow errors.
+
+**Environment variables**:
+- `NEXT_PUBLIC_*` — safe to read in browser; expose intentionally
+- All others — server-only; import only in server components, API routes, or `lib/`
+
+## Do Not Touch Without Discussion
+
+- `[PROTECTED_FILE_1]` — [reason it must not change]
+- `[PROTECTED_FILE_2]` — [reason it must not change]
+- `migrations/` — Never edit past migrations; always create a new one
+
+## Dependency Rules
+
+```
+app/ → components/, hooks/, lib/, utils/, types/
+components/ → hooks/, utils/, types/   (no lib/ imports in UI components)
+hooks/ → lib/, utils/, types/
+utils/ → types/                        (pure: no lib/, no hooks/)
+lib/ → types/                          (no internal app/ imports)
+```
+
+Violations of these rules create circular dependencies. Flag them rather than working around them.

--- a/.claude/instructions/conventions.md
+++ b/.claude/instructions/conventions.md
@@ -1,0 +1,70 @@
+# Conventions
+
+## Naming
+
+| Construct | Style | Example |
+|-----------|-------|---------|
+| React components | PascalCase | `UserProfile.tsx` |
+| Functions & hooks | camelCase | `formatDate()`, `useAuth()` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_RETRIES = 3` |
+| Types & interfaces | PascalCase | `type UserRole = ...` |
+| Filenames | kebab-case | `user-profile.tsx` |
+| CSS / Tailwind | utility classes only — avoid custom class names unless unavoidable | |
+
+## Imports
+
+Always in this order, separated by blank lines:
+
+```typescript
+// 1. External packages
+import { useState } from 'react';
+import { z } from 'zod';
+
+// 2. Internal aliases
+import { db } from '@/lib/db';
+import type { User } from '@/types/user';
+
+// 3. Relative imports
+import { formatDate } from './utils';
+```
+
+## Code Style
+
+- `const` over `let`; never `var`
+- Named exports over default exports (easier to grep and refactor)
+- `type` over `interface` unless you need declaration merging
+- No `any` — use `unknown` + type narrowing, or define a proper type
+- Co-locate styles, tests, and types with the component they belong to
+- Prefer `async/await` over `.then()` chains
+
+## Commit Messages
+
+Format: `type(scope): short description` — imperative mood, lowercase, no trailing period, under 72 characters.
+
+Types: `feat` · `fix` · `refactor` · `test` · `docs` · `chore` · `perf` · `ci`
+
+```
+feat(auth): add Google OAuth provider
+fix(api): handle expired tokens in refresh flow
+test(utils): add edge cases for formatDate
+chore(deps): upgrade prisma to v5
+```
+
+## PR and Issue Comment Formatting
+
+Write each paragraph as a **single continuous line** with no embedded newlines. GitHub renders bare newlines as line breaks, causing mid-sentence breaks in the rendered output. Separate paragraphs with a blank line.
+
+**Correct**:
+```
+This PR adds Google OAuth as an authentication provider alongside the existing email/password login.
+
+The NextAuth.js Prisma adapter stores provider tokens so downstream API calls can use them without re-authentication.
+```
+
+**Incorrect** (hard-wrapped):
+```
+This PR adds Google OAuth as an authentication provider
+alongside the existing email/password login.
+```
+
+PR titles: `type(scope): description` — under 70 characters. Use the body for detail.

--- a/.claude/instructions/git-workflow.md
+++ b/.claude/instructions/git-workflow.md
@@ -1,0 +1,60 @@
+# Git Workflow
+
+## Branch Naming
+
+`type/short-description` — kebab-case, be specific enough to identify the work.
+
+```
+feat/add-google-oauth
+fix/token-refresh-infinite-loop
+refactor/extract-auth-middleware
+docs/update-api-reference
+chore/upgrade-prisma-v5
+test/add-user-service-coverage
+```
+
+## Development Flow
+
+1. Branch from `main` — never push directly to `main`
+2. Implement changes — commit small and often
+3. Before pushing: run `[TYPECHECK]` and `[TEST_ALL]`; fix all failures
+4. Push with `-u`: `git push -u origin <branch-name>`
+5. Open a PR against `main`; link the issue with `Closes #[number]`
+
+## After Pushing to a Branch
+
+At the end of every session where you've pushed commits, provide these copy-paste commands so the user can test locally. Replace `<branch-name>` with the actual branch name:
+
+```bash
+git fetch origin
+git checkout <branch-name>
+git pull origin <branch-name>
+```
+
+Always include this block (with the real branch name substituted) in your final response before signing off.
+
+## PR Quality
+
+- **Title**: `type(scope): description` under 70 characters
+- **Body**: explain *why* the change was made, not just *what* changed (the diff shows what)
+- **No hard-wrapped lines** — write each paragraph as a single continuous line; GitHub renders bare newlines as visible line breaks
+- Reference the issue: `Closes #[number]`
+
+## Closing Issues
+
+Only close an issue when the user explicitly asks (they have tested locally and approved the PR).
+
+When closing:
+1. **Comment** with a summary of the root cause and the changes made to fix it
+2. **Close** the issue with `state: closed`, `state_reason: completed`
+
+Do not comment on or close issues automatically after pushing — there may be multiple pushes; duplicate comments are unhelpful.
+
+## Commit Hygiene
+
+- One logical change per commit
+- Commit messages: `type(scope): description` — see conventions.md
+- Never commit: `.env`, secrets, credentials, build artifacts, `node_modules`
+- Never skip hooks: `--no-verify` is not allowed
+- Never force-push to shared branches (`main`, `staging`, open PRs)
+- Resolve merge conflicts rather than discarding changes

--- a/.claude/instructions/testing.md
+++ b/.claude/instructions/testing.md
@@ -1,0 +1,61 @@
+# Testing
+
+## Strategy
+
+| Level | Scope | When to write |
+|-------|-------|---------------|
+| Unit | Pure functions, utilities, isolated components | Always |
+| Integration | API routes, DB operations, service layer | When touching DB or external services |
+| E2E | Critical user flows (login, checkout, etc.) | Sparingly — only for flows that would be catastrophic to break |
+
+Prefer unit tests. Integration tests are slower but necessary for paths that touch the database. E2E tests are expensive — add them only when a unit + integration combination cannot catch the failure.
+
+## Commands
+
+```bash
+[TEST_SINGLE]     # run one test by name (use during development)
+[TEST_ALL]        # run full suite (required before committing)
+[TEST_COVERAGE]   # coverage report (review periodically, not per-commit)
+[E2E]             # end-to-end tests (slow; run before releasing)
+```
+
+## File Conventions
+
+- **Unit / integration**: co-located with source — `utils/format.ts` → `utils/format.test.ts`
+- **E2E**: `e2e/[flow-name].spec.ts`
+- **Fixtures / factories**: `tests/factories/[entity].ts`
+- **Shared mocks**: `tests/mocks/[service].ts`
+
+## What to Test
+
+**Always test**:
+- Boundary conditions: empty arrays, null/undefined, zero, max values
+- Error paths: what happens when the DB query fails, external API is down
+- Business logic that isn't obvious from reading the code
+- Any bug that is fixed — write the failing test first, then fix
+
+**Skip testing**:
+- Third-party library internals (trust the library)
+- Trivial getters/setters with no logic
+- Presentation-only components (snapshot tests add noise without value)
+- Things that are already tested by framework infrastructure
+
+## Test Quality
+
+- One assertion focus per test — use multiple tests instead of one mega-test
+- Test names describe the scenario: `"returns null when user is not found"`
+- Test behavior, not implementation — internals can change without breaking behavior
+- No shared mutable state between tests (`beforeEach` should fully reset)
+- Async tests: always `await`, and always test the rejection/error case too
+- Prefer real implementations over mocks where the real thing is fast enough
+
+## Before Marking a Task Complete
+
+Run all of these; all must be green with zero errors:
+
+```bash
+[TEST_SINGLE]   # confirm the specific test(s) for the changed code pass
+[TYPECHECK]     # zero type errors
+[LINT]          # zero lint warnings
+[TEST_ALL]      # full suite green
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add *)",
+      "Bash(git commit*)",
+      "Bash(git push -u origin *)",
+      "Bash(git fetch origin*)",
+      "Bash(git checkout *)",
+      "Bash(git pull origin *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr create*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(rm -rf*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[LINT] 2>&1 | tail -5",
+            "timeout": 15000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/create-feature/SKILL.md
+++ b/.claude/skills/create-feature/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: create-feature
+description: Structured workflow for implementing a new feature from spec or issue through to a PR-ready branch. Usage: /create-feature <description or issue-number>
+disable-model-invocation: true
+---
+
+Implement feature: $ARGUMENTS
+
+Steps:
+1. Read the spec or issue first: `gh issue view [issue]` if an issue number was given
+2. Explore related existing code — understand the patterns in use before writing new code
+3. Plan: list every file you will create or modify before touching anything; share the plan
+4. Implement — one logical commit per meaningful unit of work; keep commits small
+5. Write tests covering the new behavior, edge cases, and error paths
+6. Run `[TYPECHECK]` — zero errors
+7. Run `[TEST_ALL]` — full suite green
+8. Run `[LINT]` — zero warnings
+9. Push: `git push -u origin <branch-name>`
+10. Open a PR: title under 70 chars; body explains what was built and why
+11. Provide the local checkout commands for the user to test
+
+Do not:
+- Add features or options beyond what was specified
+- Refactor existing code unless it directly blocks the implementation
+- Skip the test step
+- Push to `main` directly

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fix-issue
+description: End-to-end workflow to analyze and fix a GitHub issue, from reading the issue through opening a PR. Usage: /fix-issue <issue-number>
+disable-model-invocation: true
+---
+
+Analyze and fix GitHub issue: $ARGUMENTS
+
+Steps:
+1. Read the issue: `gh issue view $ARGUMENTS` — understand the reported behavior and expected behavior
+2. Reproduce mentally or with a test: write a failing test that demonstrates the bug before touching production code
+3. Explore affected code: find the root cause (use a subagent if the codebase is large)
+4. Implement the minimal fix — do not refactor unrelated code
+5. Confirm the failing test now passes: `[TEST_SINGLE]`
+6. Run `[TYPECHECK]` and `[TEST_ALL]` — all must be green
+7. Run `[LINT]` — zero warnings
+8. Commit: `fix(scope): short description` — imperative mood, under 72 chars
+9. Push: `git push -u origin <branch-name>`
+10. Open a PR: title under 70 chars; body explains root cause and approach
+11. Provide the local checkout commands for the user to test
+
+Do not close the issue automatically. Wait for the user to confirm and ask you to close it.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: review-pr
+description: Reviews a pull request for correctness, conventions, and security. Delegates to specialized subagents and posts a consolidated review. Usage: /review-pr <pr-number>
+disable-model-invocation: true
+---
+
+Review pull request: $ARGUMENTS
+
+Steps:
+1. Read the PR: `gh pr view $ARGUMENTS` — understand intent and scope
+2. Inspect all changes: `gh pr diff $ARGUMENTS`
+3. Use the `code-reviewer` subagent for correctness, conventions, and maintainability
+4. Use the `security-reviewer` subagent for vulnerability analysis
+5. Consolidate findings — remove duplicates, rank by severity
+6. Post a structured review comment with sections:
+   - **Must Fix** — blocks merging
+   - **Should Fix** — address in this PR
+   - **Consider** — optional future improvements
+   - **Looks Good** — specific strengths (be concrete)
+
+Formatting rules for the review comment:
+- Write each paragraph as a single continuous line — no mid-sentence hard wraps
+- Quote file path and line number for every specific issue (`src/api/users.ts:42`)
+- Be precise: name the vulnerability or bug, don't just say "validate input"
+- If a section is empty, omit it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# [PROJECT_NAME] — Agent Instructions
+
+> Self-contained agent instructions for this repository. Compatible with any AI coding agent (Claude, Copilot, Cursor, Codex, Gemini, etc.).
+
+## Project
+
+[One to two sentences describing the project and its primary goal.]
+
+**Stack**: [Framework] · [Language] · [Database] · [Auth] · [Styling]
+
+## Commands
+
+```bash
+[INSTALL]       # install dependencies
+[DEV]           # start dev server
+[TEST_SINGLE]   # run one test by name: [INSTALL] -- -t "test name"
+[TEST_ALL]      # run full test suite
+[TYPECHECK]     # static type check (no emit)
+[LINT]          # lint and auto-fix
+[BUILD]         # production build
+[MIGRATE]       # run database migrations
+```
+
+## Source Layout
+
+```
+src/
+  app/          # routes & pages ([App Router / Pages Router])
+  components/   # shared UI — presentational only
+  lib/          # third-party clients — initialize once, import everywhere
+  utils/        # pure helpers — no imports from lib/
+  hooks/        # custom React hooks
+  types/        # TypeScript definitions — no runtime logic
+```
+
+## Architecture
+
+- **Data flow**: [e.g., API → Server Component → Client Component via props]
+- **Auth boundary**: [e.g., Middleware-enforced; never trust client-supplied user IDs]
+- **State**: [e.g., React Query for server state; Zustand for UI state]
+- **DB access**: [e.g., Prisma ORM only — no raw SQL]
+- **Error handling**: Throw at domain boundaries; catch only at API layer or error boundaries
+
+**Do not touch**:
+- `[e.g., src/lib/db.ts]` — DB singleton; editing breaks connection pooling
+- `[e.g., src/middleware.ts]` — Auth enforcement; exceptions are intentional
+- `[e.g., migrations/]` — Never edit past migrations; create new ones
+
+## Conventions
+
+**Naming**:
+- `PascalCase` — components, types, interfaces
+- `camelCase` — functions, variables, hooks
+- `SCREAMING_SNAKE_CASE` — constants
+- `kebab-case` — filenames
+
+**Imports** (always in this order, blank line between groups):
+1. External packages
+2. Internal aliases (`@/...`)
+3. Relative imports
+
+**Commits**: `type(scope): short description` — imperative mood, no period.
+Types: `feat` `fix` `refactor` `test` `docs` `chore` `perf` `ci`
+
+**PRs and issue comments**: Write each paragraph as a single continuous line. No mid-sentence hard wraps — GitHub renders bare newlines as visible line breaks.
+
+## Git Workflow
+
+Branch naming: `type/short-description` (e.g., `feat/add-oauth`, `fix/token-refresh`)
+
+1. Branch from `main` — never push directly to `main`
+2. Implement → test → typecheck → lint
+3. Push and open a PR; reference the issue with `Closes #[number]`
+
+After pushing to a branch, provide these commands for local testing:
+
+```bash
+git fetch origin
+git checkout <branch-name>
+git pull origin <branch-name>
+```
+
+## Testing
+
+- **Unit**: pure functions, utilities, isolated components
+- **Integration**: API routes, DB operations
+- **E2E**: critical user flows only (login, checkout, etc.)
+
+Test files co-located with source: `utils/format.ts` → `utils/format.test.ts`
+
+Always test: boundary conditions, error paths, business logic edge cases.
+Skip: third-party internals, trivial getters, presentation-only snapshots.
+
+Must pass before marking complete: `[TYPECHECK]` + `[TEST_ALL]` + `[LINT]` — zero errors.
+
+## Hard Rules
+
+- Never commit `.env`, secrets, or credentials
+- Never use `--no-verify`, `--force`, or skip lint/type checks
+- Never force-push to shared branches
+- Prefer editing existing files over creating new ones
+- No error handling for scenarios that cannot happen
+- No speculative abstractions — implement exactly what was asked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,19 @@ Skip: third-party internals, trivial getters, presentation-only snapshots.
 
 Must pass before marking complete: `[TYPECHECK]` + `[TEST_ALL]` + `[LINT]` — zero errors.
 
+## Design System
+
+A `DESIGN.md` file at the project root defines the full visual design system for this project. For any UI or component work:
+
+- **Colors**: Use palette names and hex values from DESIGN.md Section 2 — never hardcode arbitrary hex values
+- **Typography**: Follow the type scale in Section 3 — sizes, weights, and line heights
+- **Components**: Match the shapes, surfaces, and states described in Section 4
+- **Spacing**: Use the base-unit grid from Section 5 — all spacing is a multiple of [4px or 8px]
+- **Responsive**: Follow breakpoints and component adaptations in Section 8
+- **Prompt help**: Section 9 provides copy-paste prompt fragments for common UI patterns
+
+If `DESIGN.md` is not yet filled in for this project, ask before inventing visual decisions.
+
 ## Hard Rules
 
 - Never commit `.env`, secrets, or credentials

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,7 @@ src/
 @.claude/instructions/conventions.md
 @.claude/instructions/git-workflow.md
 @.claude/instructions/testing.md
+
+## Design System
+
+For any UI or component work, reference @DESIGN.md for colors, typography, spacing, and component conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,51 @@
-# Claude Code — Global Instructions
+# [PROJECT_NAME]
 
-## PR and issue comment formatting
+[One to two sentences describing what this project does and who it serves.]
 
-When writing PR descriptions, issue comments, or any GitHub-facing text body, **do not hard-wrap lines**. Write each paragraph as a single continuous line with no embedded newlines. GitHub renders bare newlines as line breaks, which causes mid-sentence breaks in the rendered output. Separate paragraphs with a blank line instead.
+## Stack
 
-## After completing work on a branch
+- **Framework**: [e.g., Next.js 14 — App Router]
+- **Language**: [e.g., TypeScript 5 strict]
+- **Database**: [e.g., PostgreSQL via Prisma]
+- **Auth**: [e.g., NextAuth.js v5]
+- **Styling**: [e.g., Tailwind CSS v3]
+- **Deploy**: [e.g., Vercel + GitHub Actions]
 
-At the end of every session where you've pushed commits to a branch, provide the
-following copy-paste commands so the user can test locally. Replace
-`<branch-name>` with the actual branch name.
+## Commands
 
 ```bash
-git fetch origin
-git checkout <branch-name>
-git pull origin <branch-name>
+[INSTALL]         # e.g., pnpm install
+[DEV]             # e.g., pnpm dev  →  localhost:3000
+[TEST_SINGLE]     # e.g., pnpm test -- -t "test name"
+[TEST_ALL]        # e.g., pnpm test
+[TYPECHECK]       # e.g., pnpm typecheck
+[LINT]            # e.g., pnpm lint:fix
+[BUILD]           # e.g., pnpm build
+[MIGRATE]         # e.g., pnpm prisma migrate dev
 ```
 
-Always include this block verbatim (with the real branch name substituted) in
-your final response before signing off.
+## Source Layout
 
----
+```
+src/
+  app/          # routes & pages
+  components/   # shared UI components
+  lib/          # third-party configs (singletons)
+  utils/        # pure helpers (no side effects)
+  hooks/        # custom React hooks
+  types/        # TypeScript type definitions
+```
 
-## Closing GitHub issues with the MCP tools
+## Non-Negotiable Rules
 
-Do **not** comment on or close an issue after pushing. There may be many
-pushes with their own commit messages — duplicate issue comments are not
-needed.
+- Never commit `.env`, secrets, or credentials
+- Run `[TYPECHECK]` and `[TEST_ALL]` before marking any task complete
+- Prefer editing existing files over creating new ones
+- No speculative abstractions — implement what is asked, nothing more
 
-Wait until the user explicitly asks you to close the issue. That means the
-user has tested locally, approved the PR, and is ready to wrap up.
+## Detailed Instructions
 
-When the user asks you to close the issue, do both steps below in order.
-
-If the MCP tools appear unavailable (e.g. due to a disconnected server), do
-**not** ask the user — retry immediately using ToolSearch to load the tools
-and try again. If they are still unavailable after retrying, attempt the
-operation via the Bash tool using the `gh` CLI as a fallback (e.g.
-`gh issue comment`, `gh issue close`). Only report failure to the user after
-both methods have been attempted.
-
-### Step 1 — Comment with a summary of final changes and root cause
-
-Use `mcp__github__add_issue_comment`:
-- `owner`: `pbannan`
-- `repo`: `diffuse-mode-solutioning`
-- `issue_number`: the issue number
-- `body`: a summary of the root cause and the final changes made to fix it
-
-### Step 2 — Close the issue
-
-Use `mcp__github__issue_write`:
-- `owner`: `pbannan`
-- `repo`: `diffuse-mode-solutioning`
-- `issue_number`: the issue number
-- `method`: `update`
-- `state`: `closed`
-- `state_reason`: `completed`
+@.claude/instructions/architecture.md
+@.claude/instructions/conventions.md
+@.claude/instructions/git-workflow.md
+@.claude/instructions/testing.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,274 @@
+# DESIGN.md — [Project Name]
+
+> Machine-readable design system for AI coding agents. Defines tokens, components, and visual rules so agents generate consistent UI without per-prompt style instructions.
+>
+> **Format**: Google Stitch DESIGN.md (9-section standard).
+> **Rule**: Use descriptive language with precise values in parentheses. Avoid raw CSS class names (`rounded-xl`, `text-sm`) — use natural language ("gently curved 6px corners", "14px body text"). Avoid generic color names ("blue") — use descriptive names with hex values ("Midnight Indigo (#4F46E5)").
+
+---
+
+## 1. Visual Theme & Atmosphere
+
+[2–3 sentences describing the overall mood, emotional tone, and design philosophy. Examples:]
+
+- **Professional / dense**: "Clean, high-density interface built for power users who value information over decoration. Surfaces are minimal; whitespace is functional, not decorative. Every pixel earns its place."
+- **Friendly / spacious**: "Warm, airy interface with generous breathing room. Approachable and trustworthy — designed to feel helpful, not demanding."
+- **Dark / technical**: "Dark-first developer aesthetic with precise mechanical alignment. Prioritizes readability in low-light environments and signals technical sophistication."
+
+**Density**: [Compact / Balanced / Spacious]
+**Corner philosophy**: [Sharp (0px) / Subtle (2–4px) / Rounded (6–8px) / Very rounded (12–16px) / Pill]
+**Visual weight**: [Lightweight / Medium / Bold]
+**Motion**: [Minimal / Purposeful transitions only / Rich micro-interactions]
+
+---
+
+## 2. Color Palette & Roles
+
+### Core Palette
+
+| Role | Descriptive Name | Hex | Functional Purpose |
+|------|-----------------|-----|-------------------|
+| Primary | [e.g., Midnight Indigo] | `[#4F46E5]` | CTAs, links, active indicators |
+| Primary hover | [e.g., Deep Indigo] | `[#4338CA]` | Interactive state on primary elements |
+| Primary subtle | [e.g., Lavender Mist] | `[#EEF2FF]` | Selected rows, highlight backgrounds |
+| Secondary | [e.g., Cool Slate] | `[#64748B]` | Secondary actions, supporting accents |
+| Background | [e.g., Cloud White] | `[#FFFFFF]` | Page and layout background |
+| Surface | [e.g., Soft Pearl] | `[#F8FAFC]` | Cards, panels, elevated containers |
+| Surface raised | [e.g., Pale Silver] | `[#F1F5F9]` | Nested surfaces, hover states |
+| Border | [e.g., Cool Gray] | `[#E2E8F0]` | Dividers, input strokes, outlines |
+| Border strong | [e.g., Steel Gray] | `[#CBD5E1]` | Focused inputs, prominent dividers |
+| Text primary | [e.g., Charcoal] | `[#0F172A]` | Headings, body copy |
+| Text secondary | [e.g., Slate Gray] | `[#475569]` | Labels, metadata, captions |
+| Text tertiary | [e.g., Light Slate] | `[#94A3B8]` | Placeholders, hints, timestamps |
+| Text disabled | [e.g., Mist] | `[#CBD5E1]` | Inactive / read-only elements |
+| Text on-primary | White | `[#FFFFFF]` | Text on primary-colored surfaces |
+
+### Semantic / Feedback Colors
+
+| Role | Descriptive Name | Hex | Surface Tint Hex | Usage |
+|------|-----------------|-----|-----------------|-------|
+| Success | [e.g., Forest Green] | `[#16A34A]` | `[#F0FDF4]` | Confirmations, completed states |
+| Warning | [e.g., Amber] | `[#D97706]` | `[#FFFBEB]` | Caution, pending states |
+| Destructive | [e.g., Crimson] | `[#DC2626]` | `[#FEF2F2]` | Errors, delete actions |
+| Info | [e.g., Sky Blue] | `[#0284C7]` | `[#F0F9FF]` | Informational highlights |
+
+### Dark Mode Overrides *(if applicable)*
+
+| Role | Light | Dark |
+|------|-------|------|
+| Background | `[#FFFFFF]` | `[#09090B]` |
+| Surface | `[#F8FAFC]` | `[#18181B]` |
+| Surface raised | `[#F1F5F9]` | `[#27272A]` |
+| Border | `[#E2E8F0]` | `[#3F3F46]` |
+| Text primary | `[#0F172A]` | `[#FAFAFA]` |
+| Text secondary | `[#475569]` | `[#A1A1AA]` |
+
+---
+
+## 3. Typography Rules
+
+### Font Families
+
+- **Primary**: [e.g., Inter] — used for all UI text, headings, and body copy
+- **Monospace**: [e.g., JetBrains Mono] — code blocks, technical data, version numbers
+
+*Fallback stack*: `"[Primary]", system-ui, -apple-system, sans-serif`
+
+### Type Scale
+
+| Role | Size | Weight | Line Height | Letter Spacing | Usage |
+|------|------|--------|-------------|----------------|-------|
+| Display | [40–48px] | 800 | 1.1 | −0.02em | Hero headlines only |
+| Heading 1 | [30–36px] | 700 | 1.15 | −0.015em | Page titles |
+| Heading 2 | [22–28px] | 600–700 | 1.25 | −0.01em | Section headers |
+| Heading 3 | [18–22px] | 600 | 1.3 | 0 | Sub-headers, card titles |
+| Heading 4 | [15–18px] | 600 | 1.4 | 0 | Tight sub-headers, table headers |
+| Body large | [16–18px] | 400 | 1.6 | 0 | Lead paragraphs, feature text |
+| Body | [14–16px] | 400 | 1.5 | 0 | Default body copy |
+| Body small | [12–14px] | 400 | 1.45 | 0 | Supporting text, captions |
+| Label | [11–13px] | 500–600 | 1.2 | 0.02–0.05em | UI labels, button text, badges |
+| Code | [13px] | 400 | 1.65 | 0 | Inline code, code blocks |
+
+---
+
+## 4. Component Stylings
+
+Describe appearance as a designer would — shape, surface, shadow, state transitions. No CSS class names.
+
+### Buttons
+
+**Primary**: [Primary color] background, white label text (Label size, medium-heavy weight). [Corner description, e.g., "gently rounded 6px corners"]. [Padding, e.g., "12px top/bottom, 20px left/right"]. No shadow at rest. Hover: slightly deeper shade ([Primary hover hex]). Active: further deepened with subtle inward shadow. Disabled: [Surface raised] background with [Text disabled] label, cursor not-allowed.
+
+**Secondary**: Transparent background with a [1px Border stroke] outline. [Text primary] label. Hover: [Surface raised] background fills in. Active: border deepens to [Border strong].
+
+**Destructive**: [Destructive color] background, white label. Same shape and size as primary. Hover: darkened destructive shade.
+
+**Ghost / text**: No border, no background fill. [Primary color] label. Hover: [Primary subtle] background appears. Used for inline actions within content.
+
+**Icon button**: Square or circle, [32–40px], same corner treatment. Tooltip required on all icon-only buttons.
+
+### Input Fields
+
+[Surface] background with [1px Border stroke], [corner description]. [11–12px] top/bottom padding, [12–16px] left/right padding. Placeholder text in [Text tertiary]. Focus: border transitions to [Primary color] with a [very subtle primary glow / no glow]. Error: border becomes [Destructive] with an error message below in [Destructive] text. Success: border becomes [Success]. Disabled: [Surface raised] background, [Text disabled] text.
+
+### Cards & Containers
+
+[Surface] background, [corner description], [border or "hairline border using Border color"]. [shadow description from Section 6]. Inner padding [16–24px]. Hover (if interactive): border subtly deepens, or shadow elevates one level. Selected state: [Primary subtle] background tint with [Primary] left border accent.
+
+### Navigation — Sidebar
+
+[Surface or white] background. Item: [Text secondary] label, [icon size] leading icon. Active item: [Primary subtle] background fill with [Primary] label and icon. Hover: [Surface raised] tint. Dividers between groups use [Border color]. Collapsed state shows icons only with tooltips.
+
+### Navigation — Top Bar
+
+[Surface or white] background with a bottom [Border] hairline. Brand mark on the left, primary actions on the right. Active nav item: [Primary] underline (2–3px) or [Primary subtle] pill. Height [48–64px].
+
+### Badges / Tags
+
+Compact pill shape, [4px horizontal padding, 2px vertical], [Label small (11–12px), medium weight]. Neutral: [Surface raised] background, [Text secondary] text. Semantic variants use feedback palette surface tints as background with the corresponding strong color for text.
+
+### Modals & Dialogs
+
+Backdrop: semi-transparent [dark overlay] (40–60% opacity). Panel: [Surface or white] background, [corner description, typically more rounded than cards], [Floating elevation shadow from Section 6]. Max-width [480–640px], full-width on mobile with rounded top corners and flat bottom (bottom sheet). Closes on backdrop click and Escape key. Focus trapped inside while open.
+
+### Tables
+
+Header row: [Surface raised] background, [Text secondary] label text (Label size, medium weight), [8–12px] vertical padding. Body rows: alternating white / [Surface] background, or single color with [Border] horizontal dividers between rows. [12–14px] vertical padding per row. Hover: [Surface raised] tint on the hovered row. Selected: [Primary subtle] background.
+
+---
+
+## 5. Layout Principles
+
+### Spacing Scale
+
+Base unit: **[4px or 8px]**. All spacing values are multiples of the base unit.
+
+| Token | Value | Typical Usage |
+|-------|-------|---------------|
+| xs | 4px | Inline gaps, icon-to-label spacing |
+| sm | 8px | Tight groupings, compact padding |
+| md | 16px | Component internal padding |
+| lg | 24px | Between related elements |
+| xl | 32px | Section separators |
+| 2xl | 48px | Major section breaks |
+| 3xl | 64–96px | Page-level top/bottom padding |
+
+### Grid & Container
+
+- **Max content width**: [1280–1440px], centered
+- **Gutters**: [16px] mobile, [24px] tablet, [32px] desktop
+- **Column grid**: 12 columns on desktop, 8 on tablet, 4 on mobile
+- **Sidebar width**: [240–280px] (if applicable)
+
+### Whitespace Strategy
+
+[Describe the philosophy, e.g.: "Cards use 24px inner padding for a roomy feel. Sections breathe with 48px vertical gaps. Inline elements and list items use 8px spacing. Dense data views (tables, logs) use 12px row padding to maximize information density."]
+
+---
+
+## 6. Depth & Elevation
+
+Describe with evocative language alongside technical values.
+
+| Level | Description | CSS Shadow Value | Usage |
+|-------|-------------|-----------------|-------|
+| Flat | No depth | none | Default containers, flush-to-surface elements |
+| Raised | Whisper of depth | `0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)` | Cards, list items, interactive surfaces |
+| Lifted | Clear separation | `0 4px 12px rgba(0,0,0,0.10), 0 2px 4px rgba(0,0,0,0.06)` | Dropdowns, popovers, date pickers |
+| Floating | Prominent elevation | `0 8px 24px rgba(0,0,0,0.14), 0 4px 8px rgba(0,0,0,0.08)` | Modals, dialogs, command palettes |
+| Pinned | Directional depth | `0 2px 8px rgba(0,0,0,0.12)` | Sticky headers, fixed bottom bars |
+
+**Dark mode elevation**: On dark surfaces, prefer lighter surface colors over shadows to indicate elevation — shadows lose definition against dark backgrounds.
+
+---
+
+## 7. Do's and Don'ts
+
+### Do
+- Reference palette names (e.g., "Midnight Indigo") in designs; the hex is an implementation detail
+- Follow the [4px or 8px] spacing grid — all spacing values must be multiples of the base unit
+- Left-align body text; center only short UI labels and isolated CTAs
+- Reserve [Primary color] for one focused action per screen — it loses meaning when overused
+- Apply visible focus rings on every interactive element (keyboard accessibility is non-negotiable)
+- Pair status colors with icons or labels — never rely on color alone to communicate state
+- Use the destructive color only for genuinely irreversible actions
+
+### Don't
+- Mix more than two typefaces on one screen
+- Use opacity to create "disabled" text — use the explicit [Text disabled] token
+- Apply decorative shadows to flat designs — choose a consistent elevation story and maintain it
+- Place destructive actions adjacent to primary CTAs without visual separation or a confirmation step
+- Use fully saturated pure black (`#000000`) or pure white (`#FFFFFF`) for text on backgrounds
+- Hardcode hex values in components — always reference design tokens
+- Add new colors outside the palette without updating this file first
+
+---
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Min Width | Layout |
+|------|-----------|--------|
+| Mobile | 0 | Single column, full-width components, stacked navigation |
+| Tablet (sm) | [640px] | Two columns for cards/grids; side panels collapse to drawers |
+| Tablet (md) | [768px] | Navigation may shift from bottom bar to side panel |
+| Desktop | [1024px] | Full layout, sidebar permanently visible |
+| Wide | [1280px+] | Max-width container centered; no further layout change |
+
+### Touch Targets
+
+Minimum tap target: **44×44px** on mobile. Increase padding rather than altering visual size to meet this requirement. Interactive elements should not be placed within 8px of each other on touch surfaces.
+
+### Navigation Patterns
+
+- **Desktop**: [e.g., Persistent left sidebar]
+- **Tablet**: [e.g., Collapsible sidebar, toggle via hamburger]
+- **Mobile**: [e.g., Bottom navigation bar for primary items, full-screen drawer for secondary]
+
+### Component Adaptations
+
+- **Cards**: [X] per row on desktop → [Y] on tablet → 1 column stacked on mobile
+- **Tables**: Horizontal scroll on mobile; consider card-per-row fallback for dense tables
+- **Modals**: Full-height bottom sheet on mobile (rounded top corners, flat bottom)
+- **Sidebar**: Hidden by default on mobile; slides in from the left as a full-height drawer
+
+---
+
+## 9. Agent Prompt Guide
+
+Copy-paste fragments for generating UI consistent with this design system.
+
+### Color Reference Cheatsheet
+
+```
+Primary:          [Descriptive Name] ([#hex])
+Primary hover:    [Descriptive Name] ([#hex])
+Primary subtle:   [Descriptive Name] ([#hex])
+Background:       [Descriptive Name] ([#hex])
+Surface:          [Descriptive Name] ([#hex])
+Border:           [Descriptive Name] ([#hex])
+Text primary:     [Descriptive Name] ([#hex])
+Text secondary:   [Descriptive Name] ([#hex])
+Success:          ([#hex])  |  Warning: ([#hex])  |  Error: ([#hex])
+```
+
+### Reusable Prompt Fragments
+
+**New screen or page**:
+> "Build [screen name] following DESIGN.md. Use [Background name] as the page background. Content lives in [Surface name] cards with [corner description] and [elevation level] shadow. All typography follows Section 3's type scale. Navigation uses the [sidebar / top bar] pattern from Section 4."
+
+**Form UI**:
+> "Create [form name]. Inputs use [Surface] background with [1px Border stroke], focused state uses a [Primary] border. Submit button is primary style. Show inline validation: [Destructive] border + message below on error, [Success] border on valid. Disabled fields use [Surface raised] with [Text disabled] label."
+
+**Data table or list**:
+> "Build a [table / list] displaying [data type]. Rows use [Body small] text, [12px] vertical padding, [Border] dividers. Header row has [Surface raised] background with [Label] text. Hover row highlights with [Surface raised] tint. Selected row uses [Primary subtle] background with a [Primary] left-border accent."
+
+**Dashboard or data display**:
+> "Create a dashboard card showing [metric]. Card uses [Surface] background, [Raised elevation], [corner description]. Heading in [Heading 3] style, value in [Display or Heading 1] style using [Text primary]. Supporting text in [Text secondary]. Use [Success] / [Destructive] for positive / negative trend indicators."
+
+**Empty state**:
+> "Design an empty state for [feature]. Centered layout, [Text secondary] headline at [Heading 3] size, [Text tertiary] supporting copy at [Body] size. Icon or illustration placeholder above the text. Optional primary CTA button below."
+
+**Navigation component**:
+> "Build a [sidebar / top nav] following DESIGN.md Section 4. Active item uses [Primary subtle background + Primary label]. Inactive items use [Text secondary]. Hover uses [Surface raised] tint. Include [icon + label] pairs. On mobile, [collapse pattern from Section 8]."


### PR DESCRIPTION
Replaces the flat CLAUDE.md with a slim root that imports focused sub-files,
reducing per-session token load while maximising clarity. Adds cross-tool
AGENTS.md, three subagent definitions, three skill workflows, and a
settings.json with permission allowlists and a post-edit lint hook.

https://claude.ai/code/session_017BwQG6rH3s93UHvo8jWezb